### PR TITLE
docs: add governance and protocol addresses documentation

### DIFF
--- a/docs/addresses.mdx
+++ b/docs/addresses.mdx
@@ -1,0 +1,88 @@
+---
+title: 'Protocol Addresses'
+description: 'Key addresses for the Z Combinator protocol'
+---
+
+## Overview
+
+This page contains all the important addresses for the Z Combinator protocol. These addresses are used for treasury operations, liquidity pool management, and token emissions.
+
+---
+
+## $ZC Token Address
+
+**Address:** `GVvPZpC6ymCoiHzYJ7CWZ8LhVn9tL2AUpRjSAsLh6jZC`
+
+The official $ZC token address on Solana.
+
+<Card
+  title="View on Solscan"
+  icon="magnifying-glass"
+  href="https://solscan.io/token/GVvPZpC6ymCoiHzYJ7CWZ8LhVn9tL2AUpRjSAsLh6jZC"
+>
+  View token on Solscan
+</Card>
+
+---
+
+## Treasury Address
+
+**Address:** `ErkB6fQtyGj4WPZPABBDGDVzdfGPiMpWtH46X48skTYS`
+
+The treasury address holds protocol assets and is controlled by futarchy governance. All treasury operations are subject to governance approval through decision markets.
+
+<Card
+  title="View on Solscan"
+  icon="magnifying-glass"
+  href="https://solscan.io/account/ErkB6fQtyGj4WPZPABBDGDVzdfGPiMpWtH46X48skTYS"
+>
+  View treasury address on Solscan
+</Card>
+
+---
+
+## Protocol Authority Address
+
+**Address:** `Hq7Xh37tT4sesD6wA4DphYfxeMJRhhFWS3KVUSSGjqzc`
+
+This address holds:
+- **Liquidity Pool (LP) positions**
+- **Mint authority** for protocol tokens
+- **Update authority** for token metadata
+
+<Card
+  title="View on Solscan"
+  icon="magnifying-glass"
+  href="https://solscan.io/account/Hq7Xh37tT4sesD6wA4DphYfxeMJRhhFWS3KVUSSGjqzc"
+>
+  View protocol authority address on Solscan
+</Card>
+
+---
+
+## Development Emissions Address
+
+**Address:** `265MYhx33woRxRULwyZLLitsbhiWjgNQWzdpr3L6SxSo`
+
+This address receives daily development team emissions:
+- **1,000,000 $ZC tokens** per day
+
+<Card
+  title="View on Solscan"
+  icon="magnifying-glass"
+  href="https://solscan.io/account/265MYhx33woRxRULwyZLLitsbhiWjgNQWzdpr3L6SxSo"
+>
+  View dev emissions address on Solscan
+</Card>
+
+---
+
+## Security Notes
+
+<Warning>
+  Always verify addresses before sending any transactions. Double-check addresses on official channels before interacting with the protocol.
+</Warning>
+
+- All protocol addresses are publicly verifiable on the Solana blockchain
+- Treasury and protocol authority addresses are controlled by governance
+- Changes to protocol addresses require governance approval

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -38,6 +38,13 @@
               "errors/overview",
               "errors/status-codes"
             ]
+          },
+          {
+            "group": "Governance",
+            "pages": [
+              "governance",
+              "addresses"
+            ]
           }
         ]
       },

--- a/docs/governance.mdx
+++ b/docs/governance.mdx
@@ -1,0 +1,119 @@
+---
+title: 'Transparency & Governance'
+description: 'How $ZC governance operates through futarchy and prediction markets'
+---
+
+## Overview
+
+$ZC governance operates through futarchy, a decision-making framework where proposals are evaluated through prediction markets. The governance system is designed to maximize autonomy and verifiability while maintaining necessary oversight for operations requiring team execution.
+
+**Core Principle:** Progressively decentralize by converting non-programmatic proposals into programmatic ones wherever possible.
+
+---
+
+## Governance Structure
+
+### Programmatic Proposals
+
+**Definition:** Proposals that can be executed permissionlessly, autonomously, and verifiably through smart contracts without human intervention.
+
+**Process:** These proposals go directly to futarchy decision markets without requiring team sign-off.
+
+**Eligible Actions:**
+
+- **Emission Rate Changes**: Modifying $ZC token emission schedules
+- **Emission Redirects**: Directing continuous emissions to specific addresses or purposes
+- **ZC Token Operations**: Sending or selling $ZC emissions from protocol holdings
+- **Treasury Asset Operations**: Sending or selling non-$ZC treasury assets
+- **ZC LP Management**: Manipulating $ZC liquidity pool positions (e.g., migrating LP, rebalancing)
+
+### Non-Programmatic Proposals
+
+**Definition:** Proposals that require team execution, labor, or coordination and cannot be fully automated through smart contracts.
+
+**Process:** These proposals require team sign-off before being submitted to futarchy decision markets.
+
+**Examples:**
+- Hosting AMAs or community events
+- Creating marketing content or memes
+- Building specific protocol features
+- Fixing identified bugs
+- Publishing roadmaps or strategic documentation
+- Updating staking contract architecture
+- Adjusting fee rates on $ZC projects
+- Modifying market parameters (duration, thresholds, TWAP intervals)
+- Managing LP positions in external projects (see below)
+
+**Strategic Goal:** Continuously evaluate non-programmatic proposal types for conversion to programmatic execution where technically feasible.
+
+---
+
+## Participating in Governance
+
+### View & Trade Proposals
+
+Active governance proposals are available as prediction markets at [zc.percent.markets](https://zc.percent.markets), where you can trade on proposal outcomes.
+
+### Submit a Proposal
+
+To submit a governance proposal, complete the [proposal submission form](https://forms.gle/trMnEAxqoANLm2Er8).
+
+---
+
+## Decision Market Configuration
+
+### Market Parameters
+
+All futarchy decision markets currently operate with the following parameters:
+
+- **Duration:** 24-hour voting period
+- **Resolution Threshold:** 0.0% pass/fail gap
+- **TWAP Calculation Interval:** 1 minute
+
+**Note:** Market parameter changes are classified as non-programmatic proposals and require team approval.
+
+### Decision Criteria
+
+**Metric:** Price of $ZC token
+
+Decision criteria is currently set by the ZC team.
+
+---
+
+## Treasury & Asset Ownership
+
+**Ownership Structure:**
+- Treasury assets are owned and controlled by futarchy governance
+- Protocol LP positions are owned and controlled by futarchy governance
+- Up to 25% of protocol LP may be withdrawn to fund $ZC decision markets
+
+<Card
+  title="View Protocol Addresses"
+  icon="wallet"
+  href="/addresses"
+>
+  See all protocol addresses including treasury, authority, and emissions addresses
+</Card>
+
+---
+
+## Current Protocol Emissions
+
+**Daily:**
+- 1,000,000 $ZC to development team
+
+**Monthly:**
+- 60,000,000 $ZC to staking contract
+
+---
+
+## External LP Custody
+
+**Current Status:** $ZC currently has custody of LP positions from other projects.
+
+**Governance Process:** Manipulation of external project LP is controlled via decision markets but classified as **non-programmatic**. These proposals require:
+1. Team approval
+2. Relevant project approval/sign-off
+3. Submission to futarchy decision markets
+
+This structure ensures collaborative management of partnered assets while maintaining governance oversight.


### PR DESCRIPTION
## Summary

Added comprehensive governance and protocol addresses documentation to the docs site.

## Changes

### New Pages

1. **`docs/governance.mdx`** - Governance overview
   - Explains futarchy-based governance system
   - Differentiates programmatic vs non-programmatic proposals
   - Includes participation guide with links to markets and proposal forms
   - Documents decision market configuration
   - Details treasury ownership and protocol emissions
   - Covers external LP custody process

2. **`docs/addresses.mdx`** - Protocol addresses
   - $ZC token address with Solscan link
   - Treasury address with governance details
   - Protocol authority address (LP, mint, update authority)
   - Development emissions address
   - Security warnings and verification instructions

### Navigation Update

Updated `docs/docs.json` to add new "Governance" group under the Guide tab with both new pages.

## Context

These docs were previously maintained in a separate docs repository and have now been ported to the main zcombinatorio repo for centralized documentation management.

## Preview

The governance page includes:
- Overview of futarchy-based decision making
- Clear categorization of proposal types
- Participation links (zc.percent.markets, Google form)
- Current emission schedules
- Treasury and LP management details

The addresses page provides:
- All key protocol addresses
- Solscan links for verification
- Security warnings
- Clear ownership and authority information